### PR TITLE
Updated golang & alpine Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added Swagger spec metadata such as version that equals the version of the
   API, contact information, and license. (#3)
 
-- Changed version of Alpine Docker image used as the base image from 3.13.4
-  -> 3.13.5. (#12)
+- Changed version of Docker base images:
+
+  - Alpine: 3.13.4 -> 3.14.0 (#12, #15)
+  - Golang: 1.16.4 -> 1.16.5 (#15)
 
 ## v1.1.1 (2021-04-09)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4 AS build
+FROM golang:1.16.5 AS build
 WORKDIR /src
 ENV GO111MODULE=on
 RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
@@ -11,7 +11,7 @@ RUN deploy/update-version.sh version.yaml \
 		&& go get -t -d \
 		&& CGO_ENABLED=0 go build -o main
 
-FROM alpine:3.13.5 AS final
+FROM alpine:3.14.0 AS final
 RUN apk add --no-cache ca-certificates
 WORKDIR /app
 COPY --from=build /src/main ./


### PR DESCRIPTION
Go: v1.16.4 -> v1.16.5
Alpine: v3.13.5 -> v3.14.0
