### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.2.0 (WIP)
+## v1.2.0 (2021-07-05)
 
-- Added environment var for setting bind address and port. (#11)
+- Added environment variable `BIND_ADDRESS` for setting bind address and port,
+  which defaults to `0.0.0.0:8080` when left unset. (#11)
 
 - Added endpoint `GET /version` that returns an object of version data of the
   API itself. (#3)


### PR DESCRIPTION
## Changes

- Added environment variable `BIND_ADDRESS` for setting bind address and port,
  which defaults to `0.0.0.0:8080` when left unset. (#11)

- Added endpoint `GET /version` that returns an object of version data of the
  API itself. (#3)

- Added Swagger spec metadata such as version that equals the version of the
  API, contact information, and license. (#3)

- Changed version of Docker base images:

  - Alpine: 3.13.4 -> 3.14.0 (#12, #15)
  - Golang: 1.16.4 -> 1.16.5 (#15)

