### PR TITLE
Updated Go version note in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added Swagger spec metadata such as version that equals the version of the
   API, contact information, and license. (#3)
 
+- Changed module Go version from v1.13 to v1.16. (#3)
+
 - Changed version of Docker base images:
 
   - Alpine: 3.13.4 -> 3.14.0 (#12, #15)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dev.azure.com is not well tested.
 
 ## Development
 
-1. Install Go 1.13 or later: <https://golang.org/>
+1. Install Go 1.16 or later: <https://golang.org/>
 
 2. Install the [swaggo/swag](https://github.com/swaggo/swag) CLI globally:
 


### PR DESCRIPTION
We updated to v1.16 in #3, but forgot to update the README.md
