### PR TITLE
Add tzdata package to prod container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.2.0 (2021-07-12)
 
+- Added support for the TZ environment variable (setting timezones ex.
+  `"Europe/Stockholm"`) through the tzdata package. (#20)
+
 - Added environment variable `BIND_ADDRESS` for setting bind address and port,
   which defaults to `0.0.0.0:8080` when left unset. (#11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   via the new config `ca.certsFile` or environment variable
   `WHARF_CA_CERTSFILE`, on top of the system's/OS's cert store. (#23)
 
-## v1.2.0 (2021-07-12)
-
 - Added support for the TZ environment variable (setting timezones ex.
   `"Europe/Stockholm"`) through the tzdata package. (#20)
+
+## v1.2.0 (2021-07-12)
 
 - Added environment variable `BIND_ADDRESS` for setting bind address and port,
   which defaults to `0.0.0.0:8080` when left unset. (#11)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN deploy/update-version.sh version.yaml \
 
 FROM alpine:3.14.0 AS final
 RUN apk add --no-cache ca-certificates
+RUN apk add tzdata
 WORKDIR /app
 COPY --from=build /src/main ./
 ENTRYPOINT ["/app/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN deploy/update-version.sh version.yaml \
 		&& CGO_ENABLED=0 go build -o main
 
 FROM alpine:3.14.0 AS final
-RUN apk add --no-cache ca-certificates
-RUN apk add tzdata
+RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 COPY --from=build /src/main ./
 ENTRYPOINT ["/app/main"]


### PR DESCRIPTION
This change will allow setting timezone from the environment variable ex. TZ=Europe/Stockholm.
Changing the timezone can be relevant during certain types of key/signature checks.

Similar PRs opened for the other imaged repos:
https://github.com/iver-wharf/wharf-provider-github/pull/25
https://github.com/iver-wharf/wharf-provider-azuredevops/pull/20
https://github.com/iver-wharf/wharf-provider-gitlab/pull/20
https://github.com/iver-wharf/wharf-api/pull/40
