### PR TITLE
Fixed Makefile docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Updated wharf-core from v0.0.0 -> v1.0.0. (#14)
 
-- Added Makefile to simplify building and developing the project locally. (#21)
+- Added Makefile to simplify building and developing the project locally.
+  (#21, #22)
 
 ## v1.2.0 (2021-07-12)
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: swag
 	@echo "Built binary found at ./wharf-provider-azuredevops or ./wharf-provider-azuredevops.exe"
 
 docker:
-	@echo docker build . \
+	docker build . \
 		-t "quay.io/iver-wharf/wharf-provider-azuredevops:latest" \
 		-t "quay.io/iver-wharf/wharf-provider-azuredevops:$(version)" \
 		--build-arg BUILD_VERSION="$(version)" \


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- `make docker` only echo'd `docker build` and did not actually run it. Technically called a "boo boo" from my end.

It did go through review, so I mean, we're all to blame :)
