### PR TITLE
Updated wharf-api-client-go to v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed to return IETF RFC-7807 compatible problem responses on failures
   instead of solely JSON-formatted strings. (#14)
 
-- Updated wharf-core from v0.0.0 -> v1.1.0. (#14, #23)
+- Changed version of `github.com/iver-wharf/wharf-core` from v0.0.0 -> v1.1.0.
+  (#14, #23)
+
+- Changed version of `github.com/iver-wharf/wharf-api-client-go`
+  from v1.2.0 -> v1.3.1. (#26)
 
 - Added Makefile to simplify building and developing the project locally.
   (#21, #22, #23)

--- a/azuredevops.go
+++ b/azuredevops.go
@@ -56,7 +56,7 @@ func (m importModule) runAzureDevOpsHandler(c *gin.Context) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	client := wharfapi.Client{
-		ApiUrl:     m.config.API.URL,
+		APIURL:     m.config.API.URL,
 		AuthHeader: c.GetHeader("Authorization"),
 	}
 
@@ -78,10 +78,9 @@ func (m importModule) runAzureDevOpsHandler(c *gin.Context) {
 
 	importer := importer.NewAzureImporter(c, &client)
 	token := wharfapi.Token{
-		TokenID:    i.TokenID,
-		Token:      i.Token,
-		UserName:   i.UserName,
-		ProviderID: i.ProviderID}
+		TokenID:  i.TokenID,
+		Token:    i.Token,
+		UserName: i.UserName}
 	provider := wharfapi.Provider{
 		ProviderID: i.ProviderID,
 		Name:       i.ProviderName,
@@ -154,7 +153,7 @@ func (m importModule) prCreatedTriggerHandler(c *gin.Context) {
 	}
 
 	client := wharfapi.Client{
-		ApiUrl:     m.config.API.URL,
+		APIURL:     m.config.API.URL,
 		AuthHeader: c.GetHeader("Authorization"),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/gin-contrib/cors v1.3.0
 	github.com/gin-gonic/gin v1.7.1
-	github.com/iver-wharf/wharf-api-client-go v1.2.0
+	github.com/iver-wharf/wharf-api-client-go v1.3.1
 	github.com/iver-wharf/wharf-core v1.1.0
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
 	github.com/swaggo/gin-swagger v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iver-wharf/wharf-api-client-go v1.2.0 h1:QQt/zSUXsM2mZwDy6uNQF+tFEY0X6qb+7BzixriPduA=
-github.com/iver-wharf/wharf-api-client-go v1.2.0/go.mod h1:IzhUU97bwsz3ZF1N4X8AM51Wca41HSVC5G56q3wDZDA=
+github.com/iver-wharf/wharf-api-client-go v1.3.1 h1:R3gol3x1iHT1boZf/J0YqB1ml4SEJEVllZ6rk3gyTPU=
+github.com/iver-wharf/wharf-api-client-go v1.3.1/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
 github.com/iver-wharf/wharf-core v1.1.0 h1:vdjW+A8p0GBBcd1sB3vKwpN44t0dBrYfpY+B6ebSMbI=
 github.com/iver-wharf/wharf-core v1.1.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -386,8 +386,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
-github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -548,7 +546,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -213,7 +213,7 @@ func (i azureImporter) postBranchesToWharfWritesProblem(groupName string, projec
 }
 
 func (i azureImporter) getTokenByIDWritesProblem(tokenID uint) (wharfapi.Token, bool) {
-	token, err := i.wharf.GetTokenById(tokenID)
+	token, err := i.wharf.GetTokenByID(tokenID)
 	if err != nil || token.TokenID == 0 {
 		log.Error().WithError(err).WithUint("tokenId", token.TokenID).Message("Unable to get token.")
 		ginutil.WriteAPIClientReadError(i.c, err,
@@ -259,7 +259,7 @@ func (i azureImporter) getOrPostTokenWritesProblem(token wharfapi.Token) (wharfa
 func (i azureImporter) getOrPostProviderWritesProblem(provider wharfapi.Provider) (wharfapi.Provider, bool) {
 	var err error
 	if provider.ProviderID != 0 {
-		provider, err = i.wharf.GetProviderById(provider.ProviderID)
+		provider, err = i.wharf.GetProviderByID(provider.ProviderID)
 		if err != nil || provider.ProviderID == 0 {
 			log.Error().WithError(err).Message("Unable to get provider.")
 			ginutil.WriteAPIClientReadError(i.c, err,


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Ran

  ```console
  $ go get github.com/iver-wharf/wharf-api-client-go@v1.3.1
  ```

- Updated some method and field names as they got renamed in wharf-api-client-go v1.2.0 &rarr; v1.3.0

## Motivation

Keep the repos up to date
