### PR TITLE
Import repos, and not projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,37 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.3.0 (WIP)
+## v2.0.0 (WIP)
+
+- BREAKING: Changed import procedure to import each Azure DevOps Git repository
+  as its own Wharf project, compared to before where it imported each
+  Azure DevOps project as its own Wharf project. (#31)
+
+- BREAKING: Changed name format of imported Wharf projects. 
+
+  - Before v2.0.0:
+
+    - Wharf group name: `{azure org name}`
+    - Wharf project name: `{azure project name}`
+
+  - Since v2.0.0:
+
+    - Wharf group name: `{azure org name}/{azure project name}`
+    - Wharf project name: `{azure Git repo name}`
+
+  There are migrations in place to try and rename Wharf projects imported via
+  wharf-provider-azuredevops before v2.0.0, but that also requires the use of
+  wharf-api v4.2.0 or higher (see: <https://github.com/iver-wharf/wharf-api/pull/55>).
+
+  This may break your builds! If you rely on the Wharf group or project names
+  in your `.wharf-ci.yml` build pipeline then you need to update those
+  accordingly. Recommended to use the built-in variables `REPO_GROUP` and
+  `REPO_NAME` throughout your build pipeline instead (see: <https://iver-wharf.github.io/#/usage-wharfyml/variables/built-in-variables?id=repo_group>).
+
+- Fixed Git SSH URL when importing from <https://dev.azure.com>. (#31)
+
+- Fixed duplicate token and provider creation in wharf-api. It will now reuse
+  existing tokens and providers from the wharf-api appropriately. (#31)
 
 - Changed to return IETF RFC-7807 compatible problem responses on failures
   instead of solely JSON-formatted strings. (#14)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Import Wharf projects from Azure DevOps repositories. Mainly focused on
 importing from self hosted Azure DevOps instances, importing from
 dev.azure.com is not well tested.
 
+## Token scopes
+
+When generating a Personal Access Token (PAT) to let wharf-provider-azuredevops
+talk to Azure DevOps, you need the following permission scopes associated with
+the token:
+
+- **Code**\
+  *Source code, repositories, pull requests, and notifications*
+
+  - [x] Read
+
 ## Components
 
 - HTTP API using the [gin-gonic/gin](https://github.com/gin-gonic/gin)

--- a/azuredevops.go
+++ b/azuredevops.go
@@ -16,6 +16,10 @@ import (
 	"github.com/iver-wharf/wharf-provider-azuredevops/internal/importer"
 )
 
+const (
+	providerName = "azuredevops"
+)
+
 type importModule struct {
 	config *Config
 }
@@ -34,8 +38,6 @@ type importBody struct {
 	UploadURL string `json:"uploadUrl" example:""`
 	// used in refresh only
 	ProviderID uint `json:"providerId" example:"0"`
-	// azuredevops, gitlab or github
-	ProviderName string `json:"provider" example:"gitlab"`
 	// used in refresh only
 	ProjectID   uint   `json:"projectId" example:"0"`
 	ProjectName string `json:"project" example:"sample project name"`
@@ -83,7 +85,7 @@ func (m importModule) runAzureDevOpsHandler(c *gin.Context) {
 		UserName: i.UserName}
 	provider := wharfapi.Provider{
 		ProviderID: i.ProviderID,
-		Name:       i.ProviderName,
+		Name:       providerName,
 		URL:        i.URL,
 		UploadURL:  i.UploadURL,
 		TokenID:    i.TokenID}

--- a/azuredevops.go
+++ b/azuredevops.go
@@ -113,16 +113,13 @@ func (m importModule) runAzureDevOpsHandler(c *gin.Context) {
 }
 
 func parseRepoRefParams(wharfGroupName, wharfProjectName string) (azureOrgName, azureProjectName, azureRepoName string) {
-	slashIndex := strings.IndexRune(wharfGroupName, '/')
-	if slashIndex == -1 {
-		azureOrgName = wharfGroupName
+	azureOrgName, azureProjectName = splitStringOnceRune(wharfGroupName, '/')
+	if azureProjectName == "" {
 		azureProjectName = wharfProjectName
 		azureRepoName = ""
-		return
+	} else {
+		azureRepoName = wharfProjectName
 	}
-	azureOrgName = wharfGroupName[:slashIndex]
-	azureProjectName = wharfGroupName[slashIndex+1:]
-	azureRepoName = wharfProjectName
 	return
 }
 

--- a/azuredevops_test.go
+++ b/azuredevops_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRepoRefParams(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		wharfGroup       string
+		wharfProject     string
+		wantAzureOrg     string
+		wantAzureProject string
+		wantAzureRepo    string
+	}{
+		{
+			name:             "old v1 format",
+			wharfGroup:       "Org",
+			wharfProject:     "Proj",
+			wantAzureOrg:     "Org",
+			wantAzureProject: "Proj",
+			wantAzureRepo:    "",
+		},
+		{
+			name:             "new v2 format",
+			wharfGroup:       "Org/Proj",
+			wharfProject:     "Repo",
+			wantAzureOrg:     "Org",
+			wantAzureProject: "Proj",
+			wantAzureRepo:    "Repo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotAzureOrg, gotAzureProject, gotAzureRepo := parseRepoRefParams(tc.wharfGroup, tc.wharfProject)
+			assert.Equal(t, tc.wantAzureOrg, gotAzureOrg)
+			assert.Equal(t, tc.wantAzureProject, gotAzureProject)
+			assert.Equal(t, tc.wantAzureRepo, gotAzureRepo)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/gin-contrib/cors v1.3.0
 	github.com/gin-gonic/gin v1.7.1
-	github.com/iver-wharf/wharf-api-client-go v1.3.1
+	github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210901075426-a335f5dc518b
 	github.com/iver-wharf/wharf-core v1.1.0
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.7.1
 	github.com/iver-wharf/wharf-api-client-go v1.3.1
 	github.com/iver-wharf/wharf-core v1.1.0
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
 	github.com/swaggo/gin-swagger v1.2.0
 	github.com/swaggo/swag v1.6.3

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/gin-contrib/cors v1.3.0
 	github.com/gin-gonic/gin v1.7.1
-	github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210902054815-432845f79c7e
+	github.com/iver-wharf/wharf-api-client-go v1.4.0
 	github.com/iver-wharf/wharf-core v1.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/gin-contrib/cors v1.3.0
 	github.com/gin-gonic/gin v1.7.1
-	github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210901075426-a335f5dc518b
+	github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210902054815-432845f79c7e
 	github.com/iver-wharf/wharf-core v1.1.0
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
 	github.com/swaggo/gin-swagger v1.2.0
 	github.com/swaggo/swag v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -196,10 +196,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iver-wharf/wharf-api-client-go v1.3.1 h1:R3gol3x1iHT1boZf/J0YqB1ml4SEJEVllZ6rk3gyTPU=
-github.com/iver-wharf/wharf-api-client-go v1.3.1/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
-github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210901075426-a335f5dc518b h1:h1U6B7U6kYyT/0y3752iVkUF7PybRVSSxyWJQ5NZb9Q=
-github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210901075426-a335f5dc518b/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
+github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210902054815-432845f79c7e h1:exxOdh0sWxN+tGrMcOjJ195gGOaEuFlgLsI9gCV/RSI=
+github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210902054815-432845f79c7e/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
 github.com/iver-wharf/wharf-core v1.1.0 h1:vdjW+A8p0GBBcd1sB3vKwpN44t0dBrYfpY+B6ebSMbI=
 github.com/iver-wharf/wharf-core v1.1.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iver-wharf/wharf-api-client-go v1.3.1 h1:R3gol3x1iHT1boZf/J0YqB1ml4SEJEVllZ6rk3gyTPU=
 github.com/iver-wharf/wharf-api-client-go v1.3.1/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
+github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210901075426-a335f5dc518b h1:h1U6B7U6kYyT/0y3752iVkUF7PybRVSSxyWJQ5NZb9Q=
+github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210901075426-a335f5dc518b/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
 github.com/iver-wharf/wharf-core v1.1.0 h1:vdjW+A8p0GBBcd1sB3vKwpN44t0dBrYfpY+B6ebSMbI=
 github.com/iver-wharf/wharf-core v1.1.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210902054815-432845f79c7e h1:exxOdh0sWxN+tGrMcOjJ195gGOaEuFlgLsI9gCV/RSI=
-github.com/iver-wharf/wharf-api-client-go v1.3.2-0.20210902054815-432845f79c7e/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
+github.com/iver-wharf/wharf-api-client-go v1.4.0 h1:P1+r7ltJyYJma2g4nRfat7ugeWd4ktfC6q67KB65TeQ=
+github.com/iver-wharf/wharf-api-client-go v1.4.0/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
 github.com/iver-wharf/wharf-core v1.1.0 h1:vdjW+A8p0GBBcd1sB3vKwpN44t0dBrYfpY+B6ebSMbI=
 github.com/iver-wharf/wharf-core v1.1.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/internal/azureapi/client.go
+++ b/internal/azureapi/client.go
@@ -1,7 +1,6 @@
 package azureapi
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -25,58 +24,54 @@ type Client struct {
 }
 
 // GetProjectWritesProblem attempts to get a project from the remote provider,
-// matching the provided group and project name.
-func (c *Client) GetProjectWritesProblem(groupName, projectName string) (Project, bool) {
-	getProjectURL, err := c.newGetProject(groupName, projectName)
+// matching the provided organization and project name.
+func (c *Client) GetProjectWritesProblem(orgName, projectNameOrID string) (Project, bool) {
+	getProjectURL, err := c.newGetProject(orgName, projectNameOrID)
 
 	if err != nil {
 		errorDetail := fmt.Sprintf("Unable to build url %q for '%s/_apis/projects/%s'",
-			c.BaseURL, groupName, projectName)
+			c.BaseURL, orgName, projectNameOrID)
 
 		ginutil.WriteInvalidParamError(c.Context, err, "url", errorDetail)
 		return Project{}, false
 	}
 
-	projects := projectResponse{
-		Count: 1,
-		Value: make([]Project, 1),
-	}
-
-	err = requests.GetUnmarshalJSON(&projects.Value[0], c.UserName, c.Token, getProjectURL)
+	var project Project
+	err = requests.GetUnmarshalJSON(&project, c.UserName, c.Token, getProjectURL)
 
 	if err != nil {
 		ginutil.WriteProviderResponseError(c.Context, err,
-			fmt.Sprintf("Invalid response when getting project %q from group %q. ", projectName, groupName)+
+			fmt.Sprintf("Invalid response when getting project %q from organization %q. ", projectNameOrID, orgName)+
 				"Could be caused by invalid JSON data structure. "+
 				"Might be the result of an incompatible version of Azure DevOps.")
 		return Project{}, false
 	}
 
-	return projects.Value[0], true
+	return project, true
 }
 
 // GetProjectsWritesProblem attempts to get all projects from the specified URL
-// that are part of the provided group.
-func (c *Client) GetProjectsWritesProblem(groupName string) ([]Project, bool) {
-	getProjectsURL, err := c.newGetProjects(groupName)
+// that are part of the provided organization.
+func (c *Client) GetProjectsWritesProblem(orgName string) ([]Project, bool) {
+	getProjectsURL, err := c.newGetProjects(orgName)
 
 	if err != nil {
 		errorDetail := fmt.Sprintf("Unable to build url %q for '%s/_apis/projects'",
-			c.BaseURL, groupName)
+			c.BaseURL, orgName)
 
 		ginutil.WriteInvalidParamError(c.Context, err, "URL", errorDetail)
 		return []Project{}, false
 	}
 
-	projects := projectResponse{
-		Count: 1,
-		Value: make([]Project, 1),
+	var projects struct {
+		Count int       `json:"count"`
+		Value []Project `json:"value"`
 	}
 
 	err = requests.GetUnmarshalJSON(&projects, c.UserName, c.Token, getProjectsURL)
 	if err != nil {
 		ginutil.WriteProviderResponseError(c.Context, err,
-			fmt.Sprintf("Invalid response getting projects from group %q. ", groupName)+
+			fmt.Sprintf("Invalid response getting projects from organization %q. ", orgName)+
 				"Could be caused by invalid JSON data structure. "+
 				"Might be the result of an incompatible version of Azure DevOps.")
 		return []Project{}, false
@@ -85,61 +80,69 @@ func (c *Client) GetProjectsWritesProblem(groupName string) ([]Project, bool) {
 	return projects.Value, true
 }
 
-// GetRepositoryWritesProblem attempts to get a repository matching the
-// specified project's id using BasicAuth.
-func (c *Client) GetRepositoryWritesProblem(groupName string, project Project) (Repository, bool) {
-	urlPath, err := c.newGetRepositories(groupName, project.Name)
+// GetRepositoryWritesProblem attempts to get a single repository for the
+// specified project using BasicAuth.
+func (c *Client) GetRepositoryWritesProblem(orgName, projectNameOrID, repoNameOrID string) (Repository, bool) {
+	urlPath, err := c.newGetRepository(orgName, projectNameOrID, repoNameOrID)
 	if err != nil {
 		log.Error().WithError(err).Message("Failed to get URL.")
 		ginutil.WriteInvalidParamError(c.Context, err, "URL", fmt.Sprintf("Unable to parse URL %q", c.BaseURL))
 		return Repository{}, false
 	}
 
-	log.Debug().WithStringer("url", urlPath).Message("Get repositories URL.")
+	log.Debug().WithStringer("url", urlPath).Message("Get repository URL.")
 
-	repositories := repositoryResponse{}
-	err = requests.GetUnmarshalJSON(&repositories, c.UserName, c.Token, urlPath)
+	var repository Repository
+	err = requests.GetUnmarshalJSON(&repository, c.UserName, c.Token, urlPath)
 	if err != nil {
 		log.Error().WithError(err).Message("Failed to get project repository.")
 		ginutil.WriteProviderResponseError(c.Context, err,
 			fmt.Sprintf(
-				"Invalid response getting repositories from project %q in group %q. ",
-				project.Name, groupName)+
+				"Invalid response getting repository from repo %q from project %q in organization %q. ",
+				repoNameOrID, projectNameOrID, orgName)+
 				"Could be caused by invalid JSON data structure. "+
 				"Might be the result of an incompatible version of Azure DevOps.")
 		return Repository{}, false
 	}
 
-	if repositories.Count != 1 {
-		log.Error().WithInt("repoCount", repositories.Count).Message("One repository is required.")
-		err = errors.New("one repository is required")
-		ginutil.WriteAPIClientReadError(c.Context, err,
-			fmt.Sprintf("There were %d repositories, we need it to be 1.",
-				repositories.Count))
-		return Repository{}, false
+	return repository, true
+}
+
+// GetRepositoriesWritesProblem attempts to get all repositories for the
+// specified project using BasicAuth.
+func (c *Client) GetRepositoriesWritesProblem(orgName, projectNameOrID string) ([]Repository, bool) {
+	urlPath, err := c.newGetRepositories(orgName, projectNameOrID)
+	if err != nil {
+		log.Error().WithError(err).Message("Failed to get URL.")
+		ginutil.WriteInvalidParamError(c.Context, err, "URL", fmt.Sprintf("Unable to parse URL %q", c.BaseURL))
+		return []Repository{}, false
 	}
 
-	freshProjectID := repositories.Value[0].Project.ID
-	if freshProjectID != project.ID {
-		log.Error().
-			WithString("got", freshProjectID).
-			WithString("want", project.ID).
-			Message("Repository is not connected with project.")
-		err = errors.New("repository is not connected with project")
-		ginutil.WriteAPIClientReadError(c.Context, err,
-			fmt.Sprintf("Repository ID (%s) and project ID (%s) mismatch.",
-				freshProjectID,
-				project.ID))
-		return Repository{}, false
+	log.Debug().WithStringer("url", urlPath).Message("Get repositories URL.")
+
+	var repositories struct {
+		Count int          `json:"count"`
+		Value []Repository `json:"value"`
+	}
+	err = requests.GetUnmarshalJSON(&repositories, c.UserName, c.Token, urlPath)
+	if err != nil {
+		log.Error().WithError(err).Message("Failed to get project repository.")
+		ginutil.WriteProviderResponseError(c.Context, err,
+			fmt.Sprintf(
+				"Invalid response getting repositories from project %q in organization %q. ",
+				projectNameOrID, orgName)+
+				"Could be caused by invalid JSON data structure. "+
+				"Might be the result of an incompatible version of Azure DevOps.")
+		return []Repository{}, false
 	}
 
-	return repositories.Value[0], true
+	return repositories.Value, true
 }
 
 // GetFileWritesProblem attempts to get a file from the specified project using
 // BasicAuth.
-func (c *Client) GetFileWritesProblem(groupName, projectName, filePath string) (string, bool) {
-	urlPath, err := c.newGetFile(groupName, projectName, filePath)
+func (c *Client) GetFileWritesProblem(orgName, projectNameOrID, repoNameOrID, filePath string) (string, bool) {
+	urlPath, err := c.newGetFile(orgName, projectNameOrID, repoNameOrID, filePath)
 	if err != nil {
 		log.Error().WithError(err).Message("Failed to get URL.")
 		ginutil.WriteInvalidParamError(c.Context, err, "url", fmt.Sprintf("Unable to parse URL %q.", c.BaseURL))
@@ -152,21 +155,26 @@ func (c *Client) GetFileWritesProblem(groupName, projectName, filePath string) (
 	if err != nil {
 		log.Error().
 			WithError(err).
-			WithStringf("project", "%s/%s", groupName, projectName).
+			WithString("org", orgName).
+			WithString("project", projectNameOrID).
+			WithString("repo", repoNameOrID).
 			WithString("file", filePath).
 			Message("Failed to fetch file from project.")
 		ginutil.WriteFetchBuildDefinitionError(c.Context, err,
-			fmt.Sprintf("Unable to fetch file from project %q.", projectName))
+			fmt.Sprintf("Unable to fetch file from project %q.", projectNameOrID))
 		return "", false
 	}
 
 	return fileContents, true
 }
 
-// GetProjectBranchesWritesProblem invokes a GET request to the remote provider,
-// fetching the branches for the specified project.
-func (c *Client) GetProjectBranchesWritesProblem(groupName, projectName, refsFilter string) ([]Branch, bool) {
-	urlPath, err := c.newGetGitRefs(groupName, projectName, refsFilter)
+// GetRepositoryBranchesWritesProblem invokes a GET request to the remote
+// provider, fetching the branches for the specified repository.
+func (c *Client) GetRepositoryBranchesWritesProblem(orgName, projectNameOrID, repoNameOrID string) ([]Branch, bool) {
+	const refBranchesFilter = "heads/"
+	const refBranchesPrefix = "refs/" + refBranchesFilter
+
+	urlPath, err := c.newGetGitRefs(orgName, projectNameOrID, repoNameOrID, refBranchesFilter)
 	if err != nil {
 		ginutil.WriteInvalidParamError(c.Context, err, "URL", fmt.Sprintf("Unable to parse URL %q", c.BaseURL))
 		return []Branch{}, false
@@ -174,26 +182,29 @@ func (c *Client) GetProjectBranchesWritesProblem(groupName, projectName, refsFil
 
 	log.Debug().WithStringer("url", urlPath).Message("Get branches URL.")
 
-	projectRefs := struct {
-		Value []ref `json:"value"`
-		Count int   `json:"count"`
-	}{}
-
+	var projectRefs struct {
+		Value []struct {
+			ObjectID string  `json:"objectId"`
+			Name     string  `json:"name"`
+			Creator  creator `json:"creator"`
+			URL      string  `json:"url"`
+		} `json:"value"`
+		Count int `json:"count"`
+	}
 	err = requests.GetUnmarshalJSON(&projectRefs, c.UserName, c.Token, urlPath)
 	if err != nil {
 		ginutil.WriteProviderResponseError(c.Context, err,
 			fmt.Sprintf(
-				"Invalid response getting branches for project %q in group %q, using refs filter %q. ",
-				projectName, groupName, refsFilter)+
+				"Invalid response getting branches for project %q in organization %q, using refs filter %q. ",
+				projectNameOrID, orgName, refBranchesFilter)+
 				"Could be caused by invalid JSON data structure. "+
 				"Might be the result of an incompatible version of Azure DevOps.")
 		return []Branch{}, false
 	}
 
 	var projectBranches []Branch
-	refsFilter = fmt.Sprintf("refs/%s", refsFilter)
 	for _, ref := range projectRefs.Value {
-		name := strings.TrimPrefix(ref.Name, refsFilter)
+		name := strings.TrimPrefix(ref.Name, refBranchesPrefix)
 		projectBranches = append(projectBranches, Branch{
 			Name: name,
 			Ref:  ref.Name,
@@ -203,9 +214,9 @@ func (c *Client) GetProjectBranchesWritesProblem(groupName, projectName, refsFil
 	return projectBranches, true
 }
 
-func (c *Client) newGetRepositories(groupName, projectName string) (*url.URL, error) {
+func (c *Client) newGetRepository(orgName, projectNameOrID, repoNameOrID string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
-	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories", groupName, projectName)
+	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories/%s", orgName, projectNameOrID, repoNameOrID)
 
 	q := url.Values{}
 	q.Add("api-version", "5.0")
@@ -214,10 +225,21 @@ func (c *Client) newGetRepositories(groupName, projectName string) (*url.URL, er
 	return &urlPath, nil
 }
 
-func (c *Client) newGetFile(groupName, projectName, filePath string) (*url.URL, error) {
+func (c *Client) newGetRepositories(orgName, projectNameOrID string) (*url.URL, error) {
+	urlPath := *c.BaseURLParsed
+	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories", orgName, projectNameOrID)
+
+	q := url.Values{}
+	q.Add("api-version", "5.0")
+	urlPath.RawQuery = q.Encode()
+
+	return &urlPath, nil
+}
+
+func (c *Client) newGetFile(orgName, projectNameOrID, repoNameOrID, filePath string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
 	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories/%s/items",
-		groupName, projectName, projectName)
+		orgName, projectNameOrID, repoNameOrID)
 
 	q := url.Values{}
 	q.Add("scopePath", fmt.Sprintf("/%s", filePath))
@@ -226,9 +248,9 @@ func (c *Client) newGetFile(groupName, projectName, filePath string) (*url.URL, 
 	return &urlPath, nil
 }
 
-func (c *Client) newGetProject(groupName, projectName string) (*url.URL, error) {
+func (c *Client) newGetProject(orgName, projectNameOrID string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
-	urlPath.Path = fmt.Sprintf("%s/_apis/projects/%s", groupName, projectName)
+	urlPath.Path = fmt.Sprintf("%s/_apis/projects/%s", orgName, projectNameOrID)
 
 	q := url.Values{}
 	q.Add("api-version", "5.0")
@@ -237,9 +259,9 @@ func (c *Client) newGetProject(groupName, projectName string) (*url.URL, error) 
 	return &urlPath, nil
 }
 
-func (c *Client) newGetProjects(groupName string) (*url.URL, error) {
+func (c *Client) newGetProjects(orgName string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
-	urlPath.Path = fmt.Sprintf("%s/_apis/projects", groupName)
+	urlPath.Path = fmt.Sprintf("%s/_apis/projects", orgName)
 
 	q := url.Values{}
 	q.Add("api-version", "5.0")
@@ -248,10 +270,10 @@ func (c *Client) newGetProjects(groupName string) (*url.URL, error) {
 	return &urlPath, nil
 }
 
-func (c *Client) newGetGitRefs(groupName, projectName, refsFilter string) (*url.URL, error) {
+func (c *Client) newGetGitRefs(orgName, projectNameOrID, repoNameOrID, refsFilter string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
 	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories/%s/refs",
-		groupName, projectName, projectName)
+		orgName, projectNameOrID, repoNameOrID)
 
 	q := url.Values{}
 	q.Add("api-version", "5.0")

--- a/internal/azureapi/client.go
+++ b/internal/azureapi/client.go
@@ -216,7 +216,7 @@ func (c *Client) GetRepositoryBranchesWritesProblem(orgName, projectNameOrID, re
 
 func (c *Client) newGetRepository(orgName, projectNameOrID, repoNameOrID string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
-	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories/%s", orgName, projectNameOrID, repoNameOrID)
+	urlPath.Path = fmt.Sprintf("%s/%s/_apis/git/repositories/%s", orgName, projectNameOrID, repoNameOrID)
 
 	q := url.Values{}
 	q.Add("api-version", "5.0")
@@ -227,7 +227,7 @@ func (c *Client) newGetRepository(orgName, projectNameOrID, repoNameOrID string)
 
 func (c *Client) newGetRepositories(orgName, projectNameOrID string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
-	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories", orgName, projectNameOrID)
+	urlPath.Path = fmt.Sprintf("%s/%s/_apis/git/repositories", orgName, projectNameOrID)
 
 	q := url.Values{}
 	q.Add("api-version", "5.0")
@@ -238,7 +238,7 @@ func (c *Client) newGetRepositories(orgName, projectNameOrID string) (*url.URL, 
 
 func (c *Client) newGetFile(orgName, projectNameOrID, repoNameOrID, filePath string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
-	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories/%s/items",
+	urlPath.Path = fmt.Sprintf("%s/%s/_apis/git/repositories/%s/items",
 		orgName, projectNameOrID, repoNameOrID)
 
 	q := url.Values{}
@@ -272,7 +272,7 @@ func (c *Client) newGetProjects(orgName string) (*url.URL, error) {
 
 func (c *Client) newGetGitRefs(orgName, projectNameOrID, repoNameOrID, refsFilter string) (*url.URL, error) {
 	urlPath := *c.BaseURLParsed
-	urlPath.Path = fmt.Sprintf("%s/%s/_apis/repositories/%s/refs",
+	urlPath.Path = fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs",
 		orgName, projectNameOrID, repoNameOrID)
 
 	q := url.Values{}

--- a/internal/azureapi/models.go
+++ b/internal/azureapi/models.go
@@ -29,14 +29,14 @@ type PullRequestEvent struct {
 
 // Repository represents repository data retrieved from Azure DevOps.
 type Repository struct {
-	ID            string  `json:"id"`
-	Name          string  `json:"name"`
-	URL           string  `json:"url"`
-	Project       Project `json:"project"`
-	DefaultBranch string  `json:"defaultBranch"`
-	Size          int64   `json:"size"`
-	RemoteURL     string  `json:"remoteUrl"`
-	SSHURL        string  `json:"sshUrl"`
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	URL              string  `json:"url"`
+	Project          Project `json:"project"`
+	DefaultBranchRef string  `json:"defaultBranch"`
+	Size             int64   `json:"size"`
+	RemoteURL        string  `json:"remoteUrl"`
+	SSHURL           string  `json:"sshUrl"`
 }
 
 type creator struct {
@@ -46,21 +46,4 @@ type creator struct {
 	UniqueName  string `json:"uniqueName"`
 	ImageURL    string `json:"imageUrl"`
 	Descriptor  string `json:"descriptor"`
-}
-
-type ref struct {
-	ObjectID string  `json:"objectId"`
-	Name     string  `json:"name"`
-	Creator  creator `json:"creator"`
-	URL      string  `json:"url"`
-}
-
-type repositoryResponse struct {
-	Count int          `json:"count"`
-	Value []Repository `json:"value"`
-}
-
-type projectResponse struct {
-	Count int       `json:"count"`
-	Value []Project `json:"value"`
 }

--- a/pkg/requests/errors.go
+++ b/pkg/requests/errors.go
@@ -1,0 +1,25 @@
+package requests
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Non2xxStatusError represents a failed request response where the HTTP status
+// code was non-2xx, meaning not 200 (OK), not 201 (Created), etc.
+type Non2xxStatusError struct {
+	Status     string
+	StatusCode int
+}
+
+// Error adds compliance to the error interface.
+func (err Non2xxStatusError) Error() string {
+	return fmt.Sprintf("non-2xx HTTP status: %s", err.Status)
+}
+
+func newNon2xxStatusError(resp *http.Response) error {
+	return Non2xxStatusError{
+		Status:     resp.Status,
+		StatusCode: resp.StatusCode,
+	}
+}

--- a/pkg/requests/requests.go
+++ b/pkg/requests/requests.go
@@ -39,26 +39,26 @@ func getBodyFromRequest(user string, token string, urlPath *url.URL) ([]byte, er
 	url := urlPath.String()
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("unable to get: %w", err)
 	}
 
 	req.SetBasicAuth(user, token)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("unable to get: %w", err)
 	}
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return []byte{}, fmt.Errorf("unable to get: %s", resp.Status)
+		return []byte{}, fmt.Errorf("unable to get: %w", newNon2xxStatusError(resp))
 	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Error().WithError(err).WithStringer("url", urlPath).Message("Failed to read HTTP response body.")
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("unable to get: %w", err)
 	}
 
 	return bodyBytes, nil

--- a/util.go
+++ b/util.go
@@ -1,0 +1,16 @@
+package main
+
+import "strings"
+
+func splitStringOnceRune(value string, delimiter rune) (a, b string) {
+	const notFoundIndex = -1
+	delimiterIndex := strings.IndexRune(value, delimiter)
+	if delimiterIndex == notFoundIndex {
+		a = value
+		b = ""
+		return
+	}
+	a = value[:delimiterIndex]
+	b = value[delimiterIndex+1:] // +1 to skip the delimiter
+	return
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitStringOnceRune(t *testing.T) {
+	var testCases = []struct {
+		name  string
+		input string
+		wantA string
+		wantB string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			wantA: "",
+			wantB: "",
+		},
+		{
+			name:  "no delimiter",
+			input: "foo",
+			wantA: "foo",
+			wantB: "",
+		},
+		{
+			name:  "no latter",
+			input: "foo/",
+			wantA: "foo",
+			wantB: "",
+		},
+		{
+			name:  "no former",
+			input: "/foo",
+			wantA: "",
+			wantB: "foo",
+		},
+		{
+			name:  "only split on first delim",
+			input: "foo/bar/moo",
+			wantA: "foo",
+			wantB: "bar/moo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotA, gotB := splitStringOnceRune(tc.input, '/')
+			assert.Equal(t, tc.wantA, gotA)
+			assert.Equal(t, tc.wantB, gotB)
+		})
+	}
+}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

This is based on [RFC-0017: azuredevops-repos-and-not-projects](https://iver-wharf.github.io/rfcs/published/0017-azuredevops-repos-and-not-projects).

### Overview

- Changed to import on a repo basis instead of on a project basis. No longer assumes the repos are named the same as the projects.

### In detail

- Added parameter `repoNameOrID` in methods to be able to specify the repo name instead.
- Added name change migration, as mentioned in [RFC-0017](https://github.com/iver-wharf/rfcs/pull/17).
- Fixed `/_apis/repositories` -> `/_apis/git/repositories` API URLs.
- Fixed importer not being used as reference.
- Changed name of a lot of parameters from `groupName` to `orgName` to make it clearer when referencing Azure DevOps resources vs Wharf resources.
- Updated README.md with required PAT scopes.
- Fixed so get files to handle 404 as file not found, instead of erroring out.

## Motivation

To fix the following issues:

- Closes #24
- Closes #30
