### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.0 (WIP)
+## v2.0.0 (2021-09-07)
 
 - BREAKING: Changed import procedure to import each Azure DevOps Git repository
   as its own Wharf project, compared to before where it imported each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.0 (2021-09-07)
+## v2.0.0 (2021-09-09)
 
 - BREAKING: Changed import procedure to import each Azure DevOps Git repository
   as its own Wharf project, compared to before where it imported each


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR
- \[x] Waiting for #33 to be merged.

## Changes

- BREAKING: Changed import procedure to import each Azure DevOps Git repository as its own Wharf project, compared to before where it imported each Azure DevOps project as its own Wharf project. (#31)

- BREAKING: Changed name format of imported Wharf projects. 

  - Before v2.0.0:

    - Wharf group name: `{azure org name}`
    - Wharf project name: `{azure project name}`

  - Since v2.0.0:

    - Wharf group name: `{azure org name}/{azure project name}`
    - Wharf project name: `{azure Git repo name}`

  There are migrations in place to try and rename Wharf projects imported via wharf-provider-azuredevops before v2.0.0, but that also requires the use of wharf-api v4.2.0 or higher (see: <https://github.com/iver-wharf/wharf-api/pull/55>).

  This may break your builds! If you rely on the Wharf group or project names in your `.wharf-ci.yml` build pipeline then you need to update those accordingly. Recommended to use the built-in variables `REPO_GROUP` and `REPO_NAME` throughout your build pipeline instead (see: <https://iver-wharf.github.io/#/usage-wharfyml/variables/built-in-variables?id=repo_group>).

- BREAKING: Added a config for skipping TLS certificate chain verification to make it opt-in, where it always skipped the TLS certificates before. (#33)

  While skipping this verification is heavily discouraged, if you truly do rely on it then this can be re-enabled by setting either the YAML configuration value `ca.insecureSkipVerify` or the environment variable `WHARF_CA_INSECURESKIPVERIFY` to `true`.

- Fixed Git SSH URL when importing from <https://dev.azure.com>. (#31)

- Fixed duplicate token and provider creation in wharf-api. It will now reuse existing tokens and providers from the wharf-api appropriately. (#31)

- Changed to return IETF RFC-7807 compatible problem responses on failures instead of solely JSON-formatted strings. (#14)

- Changed version of `github.com/iver-wharf/wharf-core` from v0.0.0 -> v1.1.0. (#14, #23)

- Changed version of `github.com/iver-wharf/wharf-api-client-go` from v1.2.0 -> v1.3.1. (#26)

- Added Makefile to simplify building and developing the project locally. (#21, #22, #23)

- Added logging and custom exit code when app fails to bind the IP address and port. (#23)

- Added configs via wharf-core/pkg/config. Now supports both environment vars and YAML config files. (#23)

- Added possibility to load self-signed certs into the Go `http.DefaultClient` via the new config `ca.certsFile` or environment variable `WHARF_CA_CERTSFILE`, on top of the system's/OS's cert store. (#23)

- Added support for the TZ environment variable (setting timezones ex. `"Europe/Stockholm"`) through the tzdata package. (#20)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
