### PR TITLE
Changed InsecureSkipVerify to be opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   accordingly. Recommended to use the built-in variables `REPO_GROUP` and
   `REPO_NAME` throughout your build pipeline instead (see: <https://iver-wharf.github.io/#/usage-wharfyml/variables/built-in-variables?id=repo_group>).
 
+- BREAKING: Added a config for skipping TLS certificate chain verification to
+  make it opt-in, where it always skipped the TLS certificates before. (#33)
+
+  While skipping this verification is heavily discouraged, if you truly do
+  rely on it then this can be re-enabled by setting either the YAML
+  configuration value `ca.insecureSkipVerify` or the environment variable
+  `WHARF_CA_INSECURESKIPVERIFY` to `true`.
+
 - Fixed Git SSH URL when importing from <https://dev.azure.com>. (#31)
 
 - Fixed duplicate token and provider creation in wharf-api. It will now reuse

--- a/azuredevops.go
+++ b/azuredevops.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -55,8 +54,6 @@ type importBody struct {
 // @Failure 502 {object} problem.Response "Bad gateway"
 // @Router /azuredevops [post]
 func (m importModule) runAzureDevOpsHandler(c *gin.Context) {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
 	client := wharfapi.Client{
 		APIURL:     m.config.API.URL,
 		AuthHeader: c.GetHeader("Authorization"),
@@ -137,8 +134,6 @@ func parseRepoRefParams(wharfGroupName, wharfProjectName string) (azureOrgName, 
 // @Router /azuredevops/triggers/{projectid}/pr/created [post]
 func (m importModule) prCreatedTriggerHandler(c *gin.Context) {
 	const eventTypePullRequest string = "git.pullrequest.created"
-
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	t := azureapi.PullRequestEvent{}
 	if err := c.ShouldBindJSON(&t); err != nil {

--- a/config.go
+++ b/config.go
@@ -81,6 +81,14 @@ type CertConfig struct {
 	//
 	// Added in v1.3.0
 	CertsFile string
+
+	/// InsecureSkipVerify will disable all TLS certificate verification for
+	/// outgoing traffic from the wharf-provider-azuredevops application.
+	///
+	/// This is a major security hole and should be avoided whenever possible.
+	///
+	/// Added in v2.0.0.
+	InsecureSkipVerify bool
 }
 
 // DefaultConfig is the hard-coded default values for wharf-provider-azuredevops's

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1,10 +1,8 @@
 package importer
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/gin-gonic/gin"
@@ -103,8 +101,6 @@ func (i *azureImporter) InitWritesProblem(token wharfapi.Token, provider wharfap
 }
 
 func (i *azureImporter) ImportRepositoryWritesProblem(orgName, projectNameOrID, repoNameOrID string) bool {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
 	repo, ok := i.azure.GetRepositoryWritesProblem(orgName, projectNameOrID, repoNameOrID)
 	if !ok {
 		return false
@@ -114,7 +110,6 @@ func (i *azureImporter) ImportRepositoryWritesProblem(orgName, projectNameOrID, 
 }
 
 func (i *azureImporter) ImportProjectWritesProblem(orgName, projectNameOrID string) bool {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	repos, ok := i.azure.GetRepositoriesWritesProblem(orgName, projectNameOrID)
 	if !ok {
 		return false
@@ -129,7 +124,6 @@ func (i *azureImporter) ImportProjectWritesProblem(orgName, projectNameOrID stri
 }
 
 func (i *azureImporter) ImportOrganizationWritesProblem(groupName string) bool {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	projects, ok := i.azure.GetProjectsWritesProblem(groupName)
 	if !ok {
 		return false

--- a/main.go
+++ b/main.go
@@ -54,6 +54,18 @@ func main() {
 		http.DefaultClient = client
 	}
 
+	if config.CA.InsecureSkipVerify {
+		transport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			log.Error().
+				WithStringf("httpTransportType", "%T", http.DefaultClient).
+				Messagef("Failed to cast the HTTP transport to %T when insecurely configuring TLS to skip cert verify.", &http.Transport{})
+			os.Exit(1)
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+		log.Warn().Message("Insecurely configured TLS to skip certificate verification.")
+	}
+
 	gin.DefaultWriter = ginutil.DefaultLoggerWriter
 	gin.DefaultErrorWriter = ginutil.DefaultLoggerWriter
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added config `ca.insecureSkipVerify`/`WHARF_CA_INSECURESKIPVERIFY` 
- Removed TLS configs assignments that were scattered throughout
- Added `http.DefaultTransport.TLSConfig.InsecureSkipVerify` setting to `main.go`

## Motivation

Closes #10
