### PR TITLE
Updated Docker base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.0.1 (WIP)
+
+- Changed version of Docker base images, relying on "latest" patch version:
+
+  - Alpine: 3.14.0 -> 3.14 (#35)
+  - Golang: 1.16.5 -> 1.16 (#35)
+
 ## v2.0.0 (2021-09-09)
 
 - BREAKING: Changed import procedure to import each Azure DevOps Git repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 AS build
+FROM golang:1.16 AS build
 WORKDIR /src
 ENV GO111MODULE=on
 RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
@@ -14,7 +14,7 @@ RUN deploy/update-version.sh version.yaml \
 		&& make swag \
 		&& CGO_ENABLED=0 go build -o main
 
-FROM alpine:3.14.0 AS final
+FROM alpine:3.14 AS final
 RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 COPY --from=build /src/main ./


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to rely on latest patch version for docker base images.

## Motivation

I've now tested this locally with Trivy's CLI: https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/scanning/image/

```console
$ docker save wharf-provider-azuredevops:v2.0.1 -o v2.0.1.tar

$ trivy image --input v2.0.1.tar
2021-09-09T08:29:54.923+0200	INFO	Detected OS: alpine
2021-09-09T08:29:54.923+0200	INFO	Detecting Alpine vulnerabilities...
2021-09-09T08:29:54.923+0200	INFO	Number of language-specific files: 1
2021-09-09T08:29:54.923+0200	INFO	Detecting gobinary vulnerabilities...

v2.0.1.tar (alpine 3.14.2)
==========================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


app/main (gobinary)
===================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

Whereas v2.0.0 has:

```console
$ trivy image --input v2.0.0.tar
2021-09-09T08:30:19.213+0200	INFO	Detected OS: alpine
2021-09-09T08:30:19.213+0200	INFO	Detecting Alpine vulnerabilities...
2021-09-09T08:30:19.214+0200	INFO	Number of language-specific files: 1
2021-09-09T08:30:19.214+0200	INFO	Detecting gobinary vulnerabilities...

v2.0.0.tar (alpine 3.14.0)
==========================
Total: 5 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 2, CRITICAL: 3)

+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| apk-tools    | CVE-2021-36159   | CRITICAL | 2.12.5-r1         | 2.12.6-r0     | libfetch before 2021-07-26, as        |
|              |                  |          |                   |               | used in apk-tools, xbps, and          |
|              |                  |          |                   |               | other products, mishandles...         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36159 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libcrypto1.1 | CVE-2021-3711    |          | 1.1.1k-r0         | 1.1.1l-r0     | openssl: SM2 Decryption               |
|              |                  |          |                   |               | Buffer Overflow                       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3711  |
+              +------------------+----------+                   +               +---------------------------------------+
|              | CVE-2021-3712    | HIGH     |                   |               | openssl: Read buffer overruns         |
|              |                  |          |                   |               | processing ASN.1 strings              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3712  |
+--------------+------------------+----------+                   +               +---------------------------------------+
| libssl1.1    | CVE-2021-3711    | CRITICAL |                   |               | openssl: SM2 Decryption               |
|              |                  |          |                   |               | Buffer Overflow                       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3711  |
+              +------------------+----------+                   +               +---------------------------------------+
|              | CVE-2021-3712    | HIGH     |                   |               | openssl: Read buffer overruns         |
|              |                  |          |                   |               | processing ASN.1 strings              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3712  |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+

app/main (gobinary)
===================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
