### PR TITLE
Removed UploadURL references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Removed `internal/httputils`, which was moved to
   `github.com/iver-wharf/wharf-core/pkg/cacertutil`. (#28)
 
+- Removed `UploadURL` field from the `importBody` struct, and all references to
+  `wharfapi.Provider.UploadURL`, which will be removed in wharf-api v5.0.0 as it
+  did not provide any functionality. (#39)
+
 ## v2.0.1 (2021-09-10)
 
 - Changed version of Docker base images, relying on "latest" patch version:

--- a/azuredevops.go
+++ b/azuredevops.go
@@ -30,11 +30,10 @@ func (m importModule) register(r gin.IRouter) {
 
 type importBody struct {
 	// used in refresh only
-	TokenID   uint   `json:"tokenId" example:"0"`
-	Token     string `json:"token" example:"sample token"`
-	UserName  string `json:"user" example:"sample user name"`
-	URL       string `json:"url" example:"https://gitlab.local"`
-	UploadURL string `json:"uploadUrl" example:""`
+	TokenID  uint   `json:"tokenId" example:"0"`
+	Token    string `json:"token" example:"sample token"`
+	UserName string `json:"user" example:"sample user name"`
+	URL      string `json:"url" example:"https://gitlab.local"`
 	// used in refresh only
 	ProviderID uint `json:"providerId" example:"0"`
 	// used in refresh only
@@ -84,7 +83,6 @@ func (m importModule) runAzureDevOpsHandler(c *gin.Context) {
 		ProviderID: i.ProviderID,
 		Name:       providerName,
 		URL:        i.URL,
-		UploadURL:  i.UploadURL,
 		TokenID:    i.TokenID}
 
 	ok := importer.InitWritesProblem(token, provider, c, client)


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

- \[x] Wait for new release of wharf-api, with iver-wharf/wharf-api#82

- \[x] ~Wait for new release of wharf-api-client-go, with iver-wharf/wharf-api-client-go#21.~
EDIT: Doesn't seem like we actually need to wait for this.

## Summary

Removed `UploadURL` field from the `importBody` struct.
Removed any reference to `wharfapi.Provider.UploadURL`.

## Motivation

These fields did not provide any functionality and were thus effectively just bloat.

Required change to be compatible with https://github.com/iver-wharf/wharf-api/pull/82

Part of inter-repo change, together with:
- iver-wharf/wharf-api#82
- iver-wharf/wharf-api-client-go#21
- iver-wharf/wharf-provider-gitlab#30
- iver-wharf/wharf-provider-github#35

--
Closes #34.