### PR TITLE
Changed .wharf-ci.yml for canary builds

### DIFF
--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -1,9 +1,9 @@
 build:
-  azuredevops:
+  wharf-provider-azuredevops:
     docker:
       file: Dockerfile
-      tag: ${GIT_COMMIT},${GIT_TAG},latest
+      tag: unstable
       args:
-        - BUILD_VERSION=${GIT_TAG}
+        - BUILD_VERSION=${GIT_BRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}
         - BUILD_REF=${BUILD_REF}

--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -2,8 +2,9 @@ build:
   wharf-provider-azuredevops:
     docker:
       file: Dockerfile
-      tag: unstable
+      tag: canary
       args:
         - BUILD_VERSION=${GIT_BRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}
         - BUILD_REF=${BUILD_REF}
+        - REG=${REG_URL}/hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.16 AS build
+ARG REG=docker.io
+FROM ${REG}/library/golang:1.16 AS build
 WORKDIR /src
 ENV GO111MODULE=on
 RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
@@ -14,7 +15,8 @@ RUN deploy/update-version.sh version.yaml \
 		&& make swag \
 		&& CGO_ENABLED=0 go build -o main
 
-FROM alpine:3.14 AS final
+ARG REG=docker.io
+FROM ${REG}/library/alpine:3.14 AS final
 RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 COPY --from=build /src/main ./


### PR DESCRIPTION
## Summary

- Changed deploy tag in `.wharf-ci.yml` to `:canary`
- Changed to use our internal Docker Hub registry caching proxy in Docker builds
- Fixed Wharf build step name in `.wharf-ci.yml`

## Motivation

Minor tweaks to make the Wharf builds work and be able to build Wharf itself.

- Inspired by https://github.com/iver-wharf/wharf-api/pull/124
- Related to https://github.com/iver-wharf/iver-wharf.github.io/issues/80
