### PR TITLE
Fix windows docker build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Handle line endings for docker scripts on Windows
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `wharfapi.Provider.UploadURL`, which will be removed in wharf-api v5.0.0 as it
   did not provide any functionality. (#39)
 
-- Changed docker-build scripts for easier windows building. (#48)
+- Changed Dockerfile for easier windows building. (#48)
 
 ## v2.0.1 (2021-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `wharfapi.Provider.UploadURL`, which will be removed in wharf-api v5.0.0 as it
   did not provide any functionality. (#39)
 
+- Changed docker-build scripts for easier windows building. (#48)
+
 ## v2.0.1 (2021-09-10)
 
 - Changed version of Docker base images, relying on "latest" patch version:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ ARG BUILD_GIT_COMMIT="HEAD"
 ARG BUILD_REF="0"
 ARG BUILD_DATE=""
 RUN chmod +x deploy/update-version.sh  \
-        && deploy/update-version.sh version.yaml \
-		&& make swag \
-		&& CGO_ENABLED=0 go build -o main
+    && deploy/update-version.sh version.yaml \
+    && make swag \
+    && CGO_ENABLED=0 go build -o main
 
 ARG REG=docker.io
 FROM ${REG}/library/alpine:3.14 AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ARG BUILD_VERSION="local docker"
 ARG BUILD_GIT_COMMIT="HEAD"
 ARG BUILD_REF="0"
 ARG BUILD_DATE=""
-RUN deploy/update-version.sh version.yaml \
+RUN chmod +x deploy/update-version.sh  \
+        && deploy/update-version.sh version.yaml \
 		&& make swag \
 		&& CGO_ENABLED=0 go build -o main
 

--- a/deploy/update-version.sh
+++ b/deploy/update-version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 VERSION_FILE="${1:?'Version file must be provided'}"
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Shebang signature modified for docker runs. Had issues on docker windows.

## Motivation

This makes it easier to docker build on windows.

Also see similar changes:
- https://github.com/iver-wharf/wharf-web/pull/95
- https://github.com/iver-wharf/wharf-provider-azuredevops/pull/48
- https://github.com/iver-wharf/wharf-provider-github/pull/44
- https://github.com/iver-wharf/wharf-provider-gitlab/pull/39
- https://github.com/iver-wharf/wharf-api/pull/126