### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v3.0.0 (WIP)
+## v3.0.0 (2022-05-10)
 
 - BREAKING: Removed support for `github.com/iver-wharf/wharf-api` v4.
   Now requires a minimum of wharf-api v5.0.0. (#49)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- BREAKING: Removed support for `github.com/iver-wharf/wharf-api` v4. Now requires a minimum of wharf-api v5.0.0. (#49)

- Changed version of dependencies:

  - `github.com/gin-gonic/gin` from v1.7.4 to v1.7.7 (#50)
  - `github.com/iver-wharf/wharf-api-client-go` from v1.3.1 to v2.0.0 (#28, #49)
  - `github.com/iver-wharf/wharf-core` from v1.1.0 to v1.3.0 (#28, #47)
  - `github.com/swaggo/gin-swagger` from v1.3.1 to v1.4.3 (#50)
  - `github.com/swaggo/swag` from v1.7.1 to v1.8.1 (#50)

- Removed `internal/httputils`, which was moved to `github.com/iver-wharf/wharf-core/pkg/cacertutil`. (#28)

- Removed `UploadURL` field from the `importBody` struct, and all references to `wharfapi.Provider.UploadURL`, which will be removed in wharf-api v5.0.0 as it did not provide any functionality. (#39)

- Changed Dockerfile for easier windows building. (#48)

- Changed Go runtime from v1.16 to v1.18. (#52)

- Changed version of Docker base images:

  - Alpine: 3.14 -> 3.15 (#52)
  - Golang: 1.16 -> 1.18 (#52)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
