### PR TITLE
Release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v3.0.1 (WIP)
+## v3.0.1 (2022-05-19)
 
 - Fixed code overriding the path in the provider's URL. It will now join
   together the given URL path with the API endpoint's path. (#54)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v3.0.1 (2022-05-19)
+## v3.0.1 (2022-05-20)
 
 - Fixed code overriding the path in the provider's URL. It will now join
   together the given URL path with the API endpoint's path. (#54)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Fixed code overriding the path in the provider's URL. It will now join together the given URL path with the API endpoint's path. (#54)

  E.g:

  - Given: `https://azuredevops.example.com/customprefix`
  - Before: `https://azuredevops.example.com/DefaultCollection/_apis/projects`
  - Now: `https://azuredevops.example.com/customprefix/DefaultCollection/_apis/projects`

- Fixed not finding existing provider if one already existed in the wharf-api. (#54)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
